### PR TITLE
Add lib-add to copy task on Gruntfile.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -162,7 +162,7 @@
 					files: [{
 						expand: true,
 						cwd: 'src',
-						src:['resources/**'],
+						src:['resources/**', 'lib-app/cedar/**'],
 						dest: 'deploy/'
 					}]
 				},


### PR DESCRIPTION
For the problem of resources not loaded, just add the path on the task called "copy" on Gruntfile.js